### PR TITLE
type refactoring

### DIFF
--- a/src/abyzou/vm/compilation.nim
+++ b/src/abyzou/vm/compilation.nim
@@ -1,7 +1,7 @@
 import "."/[primitives, arrays, treewalk, types, values, ids], ../language/[expressions, number, shortstring], std/[hashes, tables, sets, strutils]
 
 defineTypeBase Meta, TypeBase(name: "Meta",
-  arguments: tupleType(Type(kind: tyBaseType, baseKind: tyFunction)))
+  arguments: @[newTypeParameter("", +Ty(Function))])
 
 #defineProperty Fields, Property(name: "Fields",
 #  argumentType: Type(kind: tyTable, keyType: box Ty(String), tableValueType: box Ty(Int32)))

--- a/src/abyzou/vm/compilation.nim
+++ b/src/abyzou/vm/compilation.nim
@@ -1,10 +1,10 @@
 import "."/[primitives, arrays, treewalk, types, values, ids], ../language/[expressions, number, shortstring], std/[hashes, tables, sets, strutils]
 
 defineTypeBase Meta, TypeBase(name: "Meta",
-  arguments: @[newTypeParameter("", +Ty(Function))])
+  arguments: @[newTypeParameter("", +Type(kind: tyBase, typeBase: FunctionTy))])
 
 #defineProperty Fields, Property(name: "Fields",
-#  argumentType: Type(kind: tyTable, keyType: box Ty(String), tableValueType: box Ty(Int32)))
+#  argumentType: Type(kind: tyTable, keyType: box Ty(String), tableValueType: box Int32Ty))
 
 # XXX (2) also Defaults purely for initialization/conversion
 # meaning only considered in function type relation
@@ -142,7 +142,7 @@ type
 
 proc compile*(scope: Scope, ex: Expression, bound: TypeBound): Statement
 
-proc evaluateStatic*(scope: Scope, ex: Expression, bound: TypeBound = +Ty(Any)): Value =
+proc evaluateStatic*(scope: Scope, ex: Expression, bound: TypeBound = +AnyTy): Value =
   scope.context.evaluateStatic(scope.compile(ex, bound).toInstruction)
 
 proc setStatic*(variable: Variable, expression: Expression) =
@@ -213,12 +213,13 @@ template constant*(value: Value, ty: Type): Statement =
   Statement(kind: skConstant, constant: value, knownType: ty)
 template constant*(value: untyped, ty: Type): Statement =
   constant(toValue(value), ty)
-template constant*(value: untyped, ty: TypeKind): Statement =
-  constant(value, Type(kind: ty))
-template constant*(value: string): Statement = constant(value, tyString)
-template constant*(value: int32): Statement = constant(value, tyInt32)
-template constant*(value: uint32): Statement = constant(value, tyUint32)
-template constant*(value: float32): Statement = constant(value, tyFloat32)
+template constant*(value: string): Statement = constant(value, StringTy)
+template constant*(value: int32): Statement = constant(value, Int32Ty)
+template constant*(value: uint32): Statement = constant(value, Uint32Ty)
+template constant*(value: float32): Statement = constant(value, Float32Ty)
+
+proc isNative(bound: TypeBound, nt: NativeType): bool {.inline.} =
+  bound.boundType.kind == tyCompound and bound.boundType.base.nativeType == nt
 
 proc compileNumber*(ex: Expression, bound: TypeBound): Statement =
   let s = $ex.number
@@ -226,9 +227,9 @@ proc compileNumber*(ex: Expression, bound: TypeBound): Statement =
   case ex.number.kind
   of Integer:
     let val = parseInt(s)
-    if bound.boundType.kind == tyFloat32:
+    if isNative(bound, ntyFloat32):
       result = constant(val.float32)
-    elif val >= 0 and bound.boundType.kind == tyUint32:
+    elif val >= 0 and isNative(bound, ntyUint32):
       result = constant(val.uint32)
     else:
       result = constant(val.int32)
@@ -237,7 +238,7 @@ proc compileNumber*(ex: Expression, bound: TypeBound): Statement =
   of Unsigned:
     result = constant(parseUInt(s).uint32)
 
-template defaultBound: untyped = +Ty(Any)
+template defaultBound: untyped = +AnyTy
 template map(ex: Expression, bound = defaultBound): Statement =
   compile(scope, ex, bound)
 template forward(ex: Expression): Statement =
@@ -311,17 +312,17 @@ proc compileProperty*(scope: Scope, ex: Expression, lhs: Statement, name: string
 proc compileMetaCall*(scope: Scope, name: string, ex: Expression, bound: TypeBound, argumentStatements: var seq[Statement]): Statement =
   result = nil
   var argumentTypes = newSeq[Type](ex.arguments.len)
-  for t in argumentTypes.mitems: t = Ty(Any)
+  for t in argumentTypes.mitems: t = AnyTy
   # XXX pass type bound as well as scope, to pass both to a compile proc
   # maybe by passing a meta call context object
   var realArgumentTypes = newSeq[Type](ex.arguments.len + 1)
-  realArgumentTypes[0] = Ty(Scope)
+  realArgumentTypes[0] = ScopeTy
   for i in 1 ..< realArgumentTypes.len:
-    realArgumentTypes[i] = union(Ty(Expression), Ty(Statement))
+    realArgumentTypes[i] = union(ExpressionTy, StatementTy)
   # get all metas first and type statements accordingly
   var allMetas = overloads(scope, name,
-    *funcType(Ty(Statement), realArgumentTypes).withProperties(
-      property(Meta, funcType(if bound.variance == Covariant: Ty(Any) else: bound.boundType, argumentTypes))))
+    *funcType(StatementTy, realArgumentTypes).withProperties(
+      property(Meta, funcType(if bound.variance == Covariant: AnyTy else: bound.boundType, argumentTypes))))
   if allMetas.len != 0:
     var makeStatement = newSeq[bool](ex.arguments.len)
     var metaTypes = newSeq[Type](allMetas.len)
@@ -330,7 +331,7 @@ proc compileMetaCall*(scope: Scope, name: string, ex: Expression, bound: TypeBou
       let metaTy = v.type.properties[Meta].baseArguments[0]
       metaTypes[i] = metaTy
       for i in 0 ..< ex.arguments.len:
-        if matchBound(+Ty(Statement), ty.param(i + 1)):
+        if matchBound(+ StatementTy, ty.param(i + 1)):
           makeStatement[i] = true
           # this should be correct but it was commonSubType before
           argumentTypes[i] = commonSuperType(argumentTypes[i], metaTy.param(i))
@@ -351,7 +352,7 @@ proc compileMetaCall*(scope: Scope, name: string, ex: Expression, bound: TypeBou
     for i, m in allMetas:
       let mt = metaTypes[i]
       if matchBound(+mt,
-        funcType(if bound.variance == Covariant: Ty(Any) else: bound.boundType, argumentTypes)):
+        funcType(if bound.variance == Covariant: AnyTy else: bound.boundType, argumentTypes)):
         superMetas.add(m)
       if matchBound(
         +funcType(if bound.variance == Covariant: union() else: bound.boundType, argumentTypes),
@@ -369,12 +370,12 @@ proc compileMetaCall*(scope: Scope, name: string, ex: Expression, bound: TypeBou
       let meta = superMetas[0]
       let ty = meta.type
       var arguments = newSeq[Statement](ex.arguments.len + 1)
-      arguments[0] = constant(scope, Ty(Scope))
+      arguments[0] = constant(scope, ScopeTy)
       for i in 0 ..< ex.arguments.len:
-        if matchBound(+Ty(Statement), ty.param(i + 1)):
-          arguments[i + 1] = constant(argumentStatements[i], Ty(Statement))
+        if matchBound(+ StatementTy, ty.param(i + 1)):
+          arguments[i + 1] = constant(argumentStatements[i], StatementTy)
         else:
-          arguments[i + 1] = constant(copy ex.arguments[i], Ty(Expression))
+          arguments[i + 1] = constant(copy ex.arguments[i], ExpressionTy)
       let call = Statement(kind: skFunctionCall,
         callee: variableGet(meta),
         arguments: arguments).toInstruction
@@ -384,11 +385,11 @@ proc compileMetaCall*(scope: Scope, name: string, ex: Expression, bound: TypeBou
         var arguments = newArray[Value](ex.arguments.len + 1)
         arguments[0] = toValue scope
         for i in 0 ..< ex.arguments.len:
-          if matchBound(+Ty(Statement), d.type.param(i + 1)):
+          if matchBound(+ StatementTy, d.type.param(i + 1)):
             arguments[i + 1] = toValue argumentStatements[i]
           else:
             arguments[i + 1] = toValue copy ex.arguments[i]
-        if checkType(toValue arguments, d.type.arguments.unbox):
+        if checkType(toValue arguments, d.type.baseArguments[0]):
           var argumentStatement = newSeq[Statement](arguments.len)
           for i, a in arguments: argumentStatement[i] = constant(a, a.getType)
           let call = Statement(kind: skFunctionCall,
@@ -409,18 +410,18 @@ proc compileRuntimeCall*(scope: Scope, ex: Expression, bound: TypeBound,
   # XXX (2) named arguments should go in the unorderedFields of the argument tuple type
   # which will then match against ordered fields with the given names
   # unsure about default arguments
-  functionType = funcType(if bound.variance == Covariant: Ty(Any) else: bound.boundType, argumentTypes)
+  functionType = funcType(if bound.variance == Covariant: AnyTy else: bound.boundType, argumentTypes)
   # lowest supertype function:
   try:
     let callee = map(ex.address, -functionType)
     result = Statement(kind: skFunctionCall,
-      knownType: callee.knownType.returnType.unbox,
+      knownType: callee.knownType.baseArguments[1],
       callee: callee,
       arguments: argumentStatements)
   except NoOverloadFoundError as e:
     # dispatch lowest subtype functions in order:
     if same(e.expression, ex.address) and ex.address.isIdentifier(name):
-      functionType.returnType = box do:
+      functionType.baseArguments[1] =
         if bound.variance == Covariant:
           union()
         else:
@@ -436,12 +437,12 @@ proc compileRuntimeCall*(scope: Scope, ex: Expression, bound: TypeBound,
             if matchBound(-argumentTypes[i], pt):
               # optimize checking types we know match
               # XXX (4?) do this recursively?
-              d[0][i] = Ty(Any)
+              d[0][i] = AnyTy
             else:
               d[0][i] = pt
           d[1] = variableGet(subs[i])
         result = Statement(kind: skDispatch,
-          knownType: functionType.returnType.unbox, # we could calculate a union here but it's not worth dealing with a typeclass
+          knownType: functionType.baseArguments[1], # we could calculate a union here but it's not worth dealing with a typeclass
           dispatchees: dispatchees,
           dispatchArguments: argumentStatements)
 
@@ -460,12 +461,12 @@ proc compileCall*(scope: Scope, ex: Expression, bound: TypeBound,
       let callee = map ex.address
       argumentStatements.insert(callee, 0)
       argumentTypes.insert(callee.knownType, 0)
-      functionType = funcType(if bound.variance == Covariant: Ty(Any) else: bound.boundType, argumentTypes)
+      functionType = funcType(if bound.variance == Covariant: AnyTy else: bound.boundType, argumentTypes)
       let overs = overloads(scope, ".call", -functionType)
       if overs.len != 0:
         let dotCall = variableGet(overs[0])
         result = Statement(kind: skFunctionCall,
-          knownType: dotCall.knownType.returnType.unbox,
+          knownType: dotCall.knownType.baseArguments[1],
           callee: callee,
           arguments: argumentStatements)
       else:
@@ -499,18 +500,18 @@ proc compileTupleExpression*(scope: Scope, ex: Expression, bound: TypeBound): St
     result.knownType.elements.add(element.knownType)
 
 proc compileArrayExpression*(scope: Scope, ex: Expression, bound: TypeBound): Statement =
-  result = Statement(kind: skList, knownType: Ty(List))
-  var boundSet = bound.boundType.kind == tyList 
+  result = Statement(kind: skList, knownType: ListTy[AnyTy])
+  var boundSet = isNative(bound, ntyList)
   var b =
     if boundSet:
-      bound.boundType.elementType.unbox * bound.variance
+      bound.boundType.baseArguments[0] * bound.variance
     else:
       defaultBound
   for e in ex.elements:
     let element = map(e, b)
     result.elements.add(element)
-    if result.knownType.elementType.isNone or result.knownType.elementType.unbox < element.knownType:
-      result.knownType.elementType = box element.knownType
+    if result.knownType.baseArguments[0].isNone or result.knownType.baseArguments[0] < element.knownType:
+      result.knownType.baseArguments[0] = element.knownType
     if not boundSet:
       b = +element.knownType
       boundSet = true
@@ -518,12 +519,12 @@ proc compileArrayExpression*(scope: Scope, ex: Expression, bound: TypeBound): St
 proc compileSetExpression*(scope: Scope, ex: Expression, bound: TypeBound): Statement =
   if ex.elements.len != 0 and (ex.elements[0].kind == Colon or
     ex.elements[0].isSingleColon):
-    result = Statement(kind: skTable, knownType: Ty(Table))
-    var boundSet = bound.boundType.kind == tyTable
+    result = Statement(kind: skTable, knownType: TableTy[AnyTy, AnyTy])
+    var boundSet = isNative(bound, ntyTable)
     var (bk, bv) =
       if boundSet:
-        (bound.boundType.keyType.unbox * bound.variance,
-          bound.boundType.tableValueType.unbox * bound.variance)
+        (bound.boundType.baseArguments[0] * bound.variance,
+          bound.boundType.baseArguments[1] * bound.variance)
       else:
         (defaultBound, defaultBound)
     for e in ex.elements:
@@ -532,27 +533,27 @@ proc compileSetExpression*(scope: Scope, ex: Expression, bound: TypeBound): Stat
       let k = map(e.left, bk)
       let v = map(e.right, bv)
       result.entries.add((key: k, value: v))
-      if result.knownType.keyType.isNone or result.knownType.keyType.unbox < k.knownType:
-        result.knownType.keyType = box k.knownType
-      if result.knownType.tableValueType.isNone or result.knownType.tableValueType.unbox < v.knownType:
-        result.knownType.tableValueType = box v.knownType
+      if result.knownType.baseArguments[0].isNone or result.knownType.baseArguments[0] < k.knownType:
+        result.knownType.baseArguments[0] = k.knownType
+      if result.knownType.baseArguments[1].isNone or result.knownType.baseArguments[1] < v.knownType:
+        result.knownType.baseArguments[1] = v.knownType
       if not boundSet:
         bk = +k.knownType
         bv = +v.knownType
         boundSet = true
   else:
-    result = Statement(kind: skSet, knownType: Ty(Set))
-    var boundSet = bound.boundType.kind == tySet 
+    result = Statement(kind: skSet, knownType: SetTy[AnyTy])
+    var boundSet = isNative(bound, ntySet) 
     var b =
       if boundSet:
-        bound.boundType.elementType.unbox * bound.variance
+        bound.boundType.baseArguments[0] * bound.variance
       else:
         defaultBound
     for e in ex.elements:
       let element = map(e, b)
       result.elements.add(element)
-      if result.knownType.elementType.isNone or result.knownType.elementType.unbox < element.knownType:
-        result.knownType.elementType = box element.knownType
+      if result.knownType.baseArguments[0].isNone or result.knownType.baseArguments[0] < element.knownType:
+        result.knownType.baseArguments[0] = element.knownType
       if not boundSet:
         b = +element.knownType
         boundSet = true
@@ -572,7 +573,7 @@ proc compileBlock*(scope: Scope, ex: Expression, bound: TypeBound): Statement =
 
 proc compile*(scope: Scope, ex: Expression, bound: TypeBound): Statement =
   case ex.kind
-  of None: result = Statement(kind: skNone, knownType: Ty(None))
+  of None: result = Statement(kind: skNone, knownType: NoneTy)
   of Number: result = compileNumber(ex, bound)
   of String, SingleQuoteString: result = constant(ex.str)
   of Wrapped: result = forward(ex.wrapped)
@@ -620,7 +621,7 @@ proc compile*(scope: Scope, ex: Expression, bound: TypeBound): Statement =
 
 type Program* = TreeWalkFunction
 
-proc compile*(ex: Expression, imports: seq[Context], bound: TypeBound = +Ty(Any)): Program =
+proc compile*(ex: Expression, imports: seq[Context], bound: TypeBound = +AnyTy): Program =
   #new(result)
   var context = newContext(imports)
   result.instruction = compile(context.top, ex, bound).toInstruction

--- a/src/abyzou/vm/compilation.nim
+++ b/src/abyzou/vm/compilation.nim
@@ -1,35 +1,7 @@
 import "."/[primitives, arrays, treewalk, types, values, ids], ../language/[expressions, number, shortstring], std/[hashes, tables, sets, strutils]
 
-when defined(gcDestructors):
-  template defineProperty(name, value): untyped {.dirty.} =
-    let `name`* = block: # !global
-      var propertySelf {.inject.}: TypeBase
-      propertySelf = value
-      propertySelf.id = newTypeBaseId()
-      propertySelf
-else:
-  template defineProperty(name, value): untyped =
-    proc getProperty: TypeBase {.gensym.} =
-      var propertySelf {.global, inject.}: TypeBase
-      if propertySelf.isNil:
-        propertySelf = value
-        propertySelf.id = newTypeBaseId()
-      result = propertySelf
-    template `name`*: TypeBase {.inject.} = getProperty()
-
-defineProperty Meta, TypeBase(name: "Meta",
-  arguments: tupleType(Type(kind: tyBaseType, baseKind: tyFunction)),
-  typeMatcher: proc (t: Type, arg: Type): TypeMatch =
-    if t.properties.hasKey(propertySelf):
-      match(arg.baseArguments[0], t.properties[propertySelf].baseArguments[0])
-    else:
-      tmFalse,
-  genericMatcher: proc (pattern: Type, arg: Type, t: Type, table: var ParameterInstantiation, variance = Covariant) =
-    let tyVal = arg.baseArguments[0]
-    if t.kind == tyFunction and tyVal.kind == tyFunction:
-      matchParameters(tyVal, t, table, variance),
-  genericFiller: proc (pattern: var Type, arg: var Type, table: ParameterInstantiation) =
-    fillParameters(arg.baseArguments[0], table))
+defineTypeBase Meta, TypeBase(name: "Meta",
+  arguments: tupleType(Type(kind: tyBaseType, baseKind: tyFunction)))
 
 #defineProperty Fields, Property(name: "Fields",
 #  argumentType: Type(kind: tyTable, keyType: box Ty(String), tableValueType: box Ty(Int32)))

--- a/src/abyzou/vm/ids.nim
+++ b/src/abyzou/vm/ids.nim
@@ -14,7 +14,7 @@ template id(kind) {.dirty.} =
     inc `counter kind`
     `kind Id`(`counter kind`)
 
-id(Property)
+id(TypeBase)
 id(TypeParameter)
 
 # XXX maybe intern identifiers or strings?

--- a/src/abyzou/vm/library/collections.nim
+++ b/src/abyzou/vm/library/collections.nim
@@ -25,7 +25,7 @@ module collections:
     result.stack.set upd.stackIndex, toValue proc (args: openarray[Value]): Value =
       args[0].referenceValue[] = args[1].toFullValueObj
   define ".[]", funcType(StatementTy, [ScopeTy, StatementTy, StatementTy]).withProperties(
-    property(Meta, funcType(AnyTy, [Type(kind: tyBaseType, baseKind: tyTuple), Int32Ty]))
+    property(Meta, funcType(AnyTy, [Type(kind: tyBase, typeBase: TupleTy), Int32Ty]))
   ), toValue proc (valueArgs: openarray[Value]): Value =
     let scope = valueArgs[0].boxedValue.scopeValue
     let index = scope.context.evaluateStatic(valueArgs[2].boxedValue.statementValue.toInstruction)

--- a/src/abyzou/vm/library/collections.nim
+++ b/src/abyzou/vm/library/collections.nim
@@ -25,7 +25,7 @@ module collections:
     result.stack.set upd.stackIndex, toValue proc (args: openarray[Value]): Value =
       args[0].referenceValue[] = args[1].toFullValueObj
   define ".[]", funcType(Ty(Statement), [Ty(Scope), Ty(Statement), Ty(Statement)]).withProperties(
-    property(Meta, toValue funcType(Ty(Any), [Type(kind: tyBaseType, baseKind: tyTuple), Ty(Int32)]))
+    property(Meta, funcType(Ty(Any), [Type(kind: tyBaseType, baseKind: tyTuple), Ty(Int32)]))
   ), toValue proc (valueArgs: openarray[Value]): Value =
     let scope = valueArgs[0].boxedValue.scopeValue
     let index = scope.context.evaluateStatic(valueArgs[2].boxedValue.statementValue.toInstruction)

--- a/src/abyzou/vm/library/collections.nim
+++ b/src/abyzou/vm/library/collections.nim
@@ -6,13 +6,13 @@ module collections:
   block reference:
     # todo: better names (maybe just copy nim)
     let T = Type(kind: tyParameter, parameter: newTypeParameter("T"))
-    let rf = define(result, "ref", funcType(Type(kind: tyReference, elementType: box T), [T]))
+    let rf = define(result, "ref", funcType(ReferenceTy[T], [T]))
     rf.genericParams = @[T.parameter]
     result.top.define(rf)
-    let urf = define(result, "unref", funcType(T, [Type(kind: tyReference, elementType: box T)]))
+    let urf = define(result, "unref", funcType(T, [ReferenceTy[T]]))
     urf.genericParams = @[T.parameter]
     result.top.define(urf)
-    let upd = define(result, "update", funcType(Ty(None), [Type(kind: tyReference, elementType: box T), T]))
+    let upd = define(result, "update", funcType(NoneTy, [ReferenceTy[T], T]))
     upd.genericParams = @[T.parameter]
     result.top.define(upd)
     result.refreshStack()
@@ -24,8 +24,8 @@ module collections:
       args[0].referenceValue[].toSmallValue
     result.stack.set upd.stackIndex, toValue proc (args: openarray[Value]): Value =
       args[0].referenceValue[] = args[1].toFullValueObj
-  define ".[]", funcType(Ty(Statement), [Ty(Scope), Ty(Statement), Ty(Statement)]).withProperties(
-    property(Meta, funcType(Ty(Any), [Type(kind: tyBaseType, baseKind: tyTuple), Ty(Int32)]))
+  define ".[]", funcType(StatementTy, [ScopeTy, StatementTy, StatementTy]).withProperties(
+    property(Meta, funcType(AnyTy, [Type(kind: tyBaseType, baseKind: tyTuple), Int32Ty]))
   ), toValue proc (valueArgs: openarray[Value]): Value =
     let scope = valueArgs[0].boxedValue.scopeValue
     let index = scope.context.evaluateStatic(valueArgs[2].boxedValue.statementValue.toInstruction)

--- a/src/abyzou/vm/library/common.nim
+++ b/src/abyzou/vm/library/common.nim
@@ -22,12 +22,12 @@ proc define*(context: Context, n: string, typ: Type, x: sink Value) =
 proc templType*(arity: int): Type {.inline.} =
   var args = newSeq[Type](arity + 1)
   var bArgs = newSeq[Type](arity)
-  args[0] = Ty(Scope)
+  args[0] = ScopeTy
   for i in 0 ..< arity:
-    args[i + 1] = Ty(Expression)
-    bArgs[i] = Ty(Any)
-  result = funcType(Ty(Statement), args)
-  result.properties = properties(property(Meta, funcType(Ty(Any), bArgs)))
+    args[i + 1] = ExpressionTy
+    bArgs[i] = AnyTy
+  result = funcType(StatementTy, args)
+  result.properties = properties(property(Meta, funcType(AnyTy, bArgs)))
 
 template doTempl*(body): untyped =
   (proc (valueArgs: openarray[Value]): Value {.nimcall.} =
@@ -40,19 +40,19 @@ template doTempl*(body): untyped =
 proc typedTemplType*(arity: int): Type {.inline.} =
   var args = newSeq[Type](arity + 1)
   var bArgs = newSeq[Type](arity)
-  args[0] = Ty(Scope)
+  args[0] = ScopeTy
   for i in 0 ..< arity:
-    args[i + 1] = Ty(Statement)
-    bArgs[i] = Ty(Any)
-  result = funcType(Ty(Statement), args)
-  result.properties = properties(property(Meta, funcType(Ty(Any), bArgs)))
+    args[i + 1] = StatementTy
+    bArgs[i] = AnyTy
+  result = funcType(StatementTy, args)
+  result.properties = properties(property(Meta, funcType(AnyTy, bArgs)))
 
 proc typedTemplType*(realArgs: openarray[Type], returnType: Type): Type {.inline.} =
   var args = newSeq[Type](realArgs.len + 1)
-  args[0] = Ty(Scope)
+  args[0] = ScopeTy
   for i in 0 ..< realArgs.len:
-    args[i + 1] = Ty(Statement)
-  result = funcType(Ty(Statement), args)
+    args[i + 1] = StatementTy
+  result = funcType(StatementTy, args)
   result.properties = properties(property(Meta, funcType(returnType, realArgs)))
 
 template doTypedTempl*(body): untyped =

--- a/src/abyzou/vm/library/common.nim
+++ b/src/abyzou/vm/library/common.nim
@@ -1,4 +1,4 @@
-import ".."/[primitives, compilation, types, values], ../../language/expressions, std/[tables]
+import ".."/[primitives, compilation, types], ../../language/expressions, std/[tables]
 
 proc define*(scope: Scope, n: string, typ: Type): Variable =
   result = newVariable(n, typ)
@@ -27,7 +27,7 @@ proc templType*(arity: int): Type {.inline.} =
     args[i + 1] = Ty(Expression)
     bArgs[i] = Ty(Any)
   result = funcType(Ty(Statement), args)
-  result.properties = properties(property(Meta, toValue funcType(Ty(Any), bArgs)))
+  result.properties = properties(property(Meta, funcType(Ty(Any), bArgs)))
 
 template doTempl*(body): untyped =
   (proc (valueArgs: openarray[Value]): Value {.nimcall.} =
@@ -45,7 +45,7 @@ proc typedTemplType*(arity: int): Type {.inline.} =
     args[i + 1] = Ty(Statement)
     bArgs[i] = Ty(Any)
   result = funcType(Ty(Statement), args)
-  result.properties = properties(property(Meta, toValue funcType(Ty(Any), bArgs)))
+  result.properties = properties(property(Meta, funcType(Ty(Any), bArgs)))
 
 proc typedTemplType*(realArgs: openarray[Type], returnType: Type): Type {.inline.} =
   var args = newSeq[Type](realArgs.len + 1)
@@ -53,7 +53,7 @@ proc typedTemplType*(realArgs: openarray[Type], returnType: Type): Type {.inline
   for i in 0 ..< realArgs.len:
     args[i + 1] = Ty(Statement)
   result = funcType(Ty(Statement), args)
-  result.properties = properties(property(Meta, toValue funcType(returnType, realArgs)))
+  result.properties = properties(property(Meta, funcType(returnType, realArgs)))
 
 template doTypedTempl*(body): untyped =
   (proc (valueArgs: openarray[Value]): Value {.nimcall.} =

--- a/src/abyzou/vm/library/logic.nim
+++ b/src/abyzou/vm/library/logic.nim
@@ -11,7 +11,7 @@ module logic:
   # these don't need to be varargs, they just are to make sure varargs work
   define "and",
     funcTypeWithVarargs(Ty(Statement), [Ty(Scope)], Ty(Statement)).withProperties(
-      property(Meta, toValue funcTypeWithVarargs(Ty(Bool), [], Ty(Bool)))),
+      property(Meta, funcTypeWithVarargs(Ty(Bool), [], Ty(Bool)))),
     toValue proc (valueArgs: openarray[Value]): Value =
       var res = valueArgs[^1].boxedValue.statementValue
       if valueArgs.len > 1:
@@ -24,7 +24,7 @@ module logic:
       result = toValue res
   define "or",
     funcTypeWithVarargs(Ty(Statement), [Ty(Scope)], Ty(Statement)).withProperties(
-      property(Meta, toValue funcTypeWithVarargs(Ty(Bool), [], Ty(Bool)))),
+      property(Meta, funcTypeWithVarargs(Ty(Bool), [], Ty(Bool)))),
     toValue proc (valueArgs: openarray[Value]): Value =
       var res = valueArgs[^1].boxedValue.statementValue
       if valueArgs.len > 1:
@@ -38,7 +38,7 @@ module logic:
   fn "xor", [Ty(Bool), Ty(Bool)], Ty(Bool):
     toValue(args[0].boolValue xor args[1].boolValue)
   define "if", funcType(Ty(Statement), [Ty(Scope), Ty(Statement), Ty(Expression)]).withProperties(
-    property(Meta, toValue funcType(Ty(Any), [Ty(Bool), Ty(Any)]))
+    property(Meta, funcType(Ty(Any), [Ty(Bool), Ty(Any)]))
   ), toValue proc (valueArgs: openarray[Value]): Value = 
     let sc = valueArgs[0].boxedValue.scopeValue.childScope()
     result = toValue Statement(kind: skIf,
@@ -46,7 +46,7 @@ module logic:
       ifTrue: sc.compile(valueArgs[2].boxedValue.expressionValue, +Ty(Any)),
       ifFalse: Statement(kind: skNone))
   define "if", funcType(Ty(Statement), [Ty(Scope), Ty(Statement), Ty(Expression), Ty(Expression)]).withProperties(
-    property(Meta, toValue funcType(Ty(Any), [Ty(Bool), Ty(Any), Ty(Any)]))
+    property(Meta, funcType(Ty(Any), [Ty(Bool), Ty(Any), Ty(Any)]))
   ), toValue proc (valueArgs: openarray[Value]): Value = 
     var els = valueArgs[3].boxedValue.expressionValue
     if els.kind == Colon and els.left.isIdentifier(ident) and ident == "else":
@@ -61,7 +61,7 @@ module logic:
     res.knownType = commonSuperType(res.ifTrue.knownType, res.ifFalse.knownType)
     result = toValue(res)
   define "while", funcType(Ty(Statement), [Ty(Scope), Ty(Statement), Ty(Expression)]).withProperties(
-    property(Meta, toValue funcType(union(), [Ty(Bool), union()]))
+    property(Meta, funcType(union(), [Ty(Bool), union()]))
   ), toValue proc (valueArgs: openarray[Value]): Value = 
     let sc = valueArgs[0].boxedValue.scopeValue.childScope()
     result = toValue Statement(kind: skWhile,

--- a/src/abyzou/vm/library/numbers.nim
+++ b/src/abyzou/vm/library/numbers.nim
@@ -9,13 +9,17 @@ macro callOp(op: static string, args: varargs[untyped]): untyped =
 
 import std/math
 
+template Ty(t: type uint32): Type = Uint32Ty
+template Ty(t: type int32): Type = Int32Ty
+template Ty(t: type float32): Type = Float32Ty
+
 module numbers:
-  define "Int", Ty(Int32)
-  define "Float", Ty(Float32)
-  define "Uint", Ty(Uint32)
-  define "Int64", Ty(Int64)
-  define "Float64", Ty(Float64)
-  define "Uint64", Ty(Uint64)
+  define "Int", Int32Ty
+  define "Float", Float32Ty
+  define "Uint", Uint32Ty
+  define "Int64", Int64Ty
+  define "Float64", Float64Ty
+  define "Uint64", Uint64Ty
   template unarySingle(op: static string, k) =
     fn op, [Ty(`k`)], Ty(`k`):
       toValue callOp(`op`, args[0].`k Value`)
@@ -37,7 +41,7 @@ module numbers:
     binarySingle op, uint32
     binarySingle op, float32
   template binarySingleBool(op: static string, k) =
-    fn op, [Ty(`k`), Ty(`k`)], Ty(Bool):
+    fn op, [Ty(`k`), Ty(`k`)], BoolTy:
       toValue callOp(`op`, args[0].`k Value`, args[1].`k Value`)
   template binaryBool(op: static string) =
     binarySingleBool op, int32
@@ -54,7 +58,7 @@ module numbers:
   binarySingle "div", int32
   binarySingle "div", uint32
   template floatDivide(k) =
-    fn "/", [Ty(`k`), Ty(`k`)], Ty(Float32):
+    fn "/", [Ty(`k`), Ty(`k`)], Float32Ty:
       toValue args[0].`k Value` / args[1].`k Value`
   floatDivide int32
   floatDivide float32

--- a/src/abyzou/vm/library/types.nim
+++ b/src/abyzou/vm/library/types.nim
@@ -3,20 +3,20 @@ import ".."/[primitives, compilation, values]
 import common
 
 module types:
-  define "Any", Ty(Any)
-  define "None", Ty(None)
-  typedTempl "type_of", [Ty(Any)], Type(kind: tyType, typeValue: Ty(Any).box):
+  define "Any", AnyTy
+  define "None", NoneTy
+  typedTempl "type_of", [AnyTy], TypeTy[AnyTy]:
     let t = args[0].knownType
-    result = toValue constant(t, Type(kind: tyType, typeValue: t.box))
+    result = toValue constant(t, TypeTy[t])
   {.push hints: off.}
-  typedTempl "cast", [Ty(Any), Type(kind: tyType, typeValue: Ty(Any).box)], Ty(Any):
+  typedTempl "cast", [AnyTy, TypeTy[AnyTy]], AnyTy:
     let newStmt = new(Statement)
     newStmt[] = args[0][]
     newStmt.knownType = scope.context.evaluateStatic(args[1].toInstruction).boxedValue.typeValue
     result = toValue newStmt
   {.pop.}
   when false:
-    let anyType = Type(kind: tyType, typeValue: Ty(Any))
+    let anyType = Type(kind: tyType, typeValue: AnyTy)
     fn "functionType", [anyType], anyType:
       result = toValue Type(kind: tyFunction, arguments: seq[Type] @[], returnType: args[0].typeValue)
     fn "functionType", [anyType, anyType], anyType:

--- a/src/abyzou/vm/primitives.nim
+++ b/src/abyzou/vm/primitives.nim
@@ -171,16 +171,16 @@ type
   ParameterInstantiation* = Table[TypeParameter, Type]
 
   TypeBase* = ref object
+    # XXX generics?
     id*: TypeBaseId
     name*: string
     arguments*: Type # tuple type
-    # these are supposed to act on `prop.value`:
-    typeMatcher*: proc (t: Type, thisType: Type): TypeMatch
+    typeMatcher*: proc (pattern, t: Type): TypeMatch
     valueMatcher*: proc (v: Value, thisType: Type): bool
     # XXX (6) maybe add compare
     # not sure if these are temporary:
-    genericMatcher*: proc (pattern: Type, thisType: Type, t: Type, table: var ParameterInstantiation, variance = Covariant)
-    genericFiller*: proc (pattern: var Type, thisType: var Type, table: ParameterInstantiation)
+    genericMatcher*: proc (pattern: Type, t: Type, table: var ParameterInstantiation, variance = Covariant)
+    genericFiller*: proc (pattern: var Type, table: ParameterInstantiation)
 
   TypeParameter* = ref object
     id*: TypeParameterId # this needs to be assigned
@@ -190,6 +190,7 @@ type
   Type* = object
     # XXX (3) for easier generics etc maybe just have a base type, argument types, and properties
     properties*: Table[TypeBase, Type]
+      # can be a multitable later on
     case kind*: TypeKind
     of tyCompound:
       base*: TypeBase

--- a/src/abyzou/vm/primitives.nim
+++ b/src/abyzou/vm/primitives.nim
@@ -173,12 +173,13 @@ type
 
   NativeType* = enum
     ntyNone,
+    # weird concrete
+    ntyTuple,
     # concrete
     ntyNoneValue,
     ntyInt32, ntyUint32, ntyFloat32, ntyBool,
     ntyInt64, ntyUint64, ntyFloat64,
     ntyReference,
-    ntyTuple, # XXX (2) make into tyComposite, tuple, named tuple, array (i.e. int^20) all at once
     ntyFunction,
     ntyList,
     ntyString,
@@ -194,8 +195,7 @@ type
     id*: TypeBaseId
     name*: string
     nativeType*: NativeType
-    arguments*: Type # tuple type
-    genericParams*: seq[TypeParameter]
+    arguments*: seq[TypeParameter]
     typeMatcher*: proc (pattern, t: Type): TypeMatch
     valueMatcher*: proc (v: Value, thisType: Type): bool
     # XXX (6) maybe add compare

--- a/src/abyzou/vm/primitives.nim
+++ b/src/abyzou/vm/primitives.nim
@@ -179,7 +179,7 @@ type
     ntyContravariant
 
   TypeBase* = ref object
-    # XXX generics?
+    # XXX (3) check arguments at generic fill time
     id*: TypeBaseId
     name*: string
     nativeType*: NativeType
@@ -203,6 +203,8 @@ type
     case kind*: TypeKind
     of tyNone, tyAny: discard
     of tyCompound:
+      # XXX seq might cause performance drop, add tySingleCompound, tyDoubleCompound etc
+      # or optimize Array like that and use it
       base*: TypeBase
       baseArguments*: seq[Type]
     of tyTuple:
@@ -782,8 +784,8 @@ TypeTy.arguments = toTypeParams [+Type(kind: tyBase, typeBase: TypeTy)]
 
 nativeType ContravariantTy, ntyContravariant, [+AnyTy]
 
-proc `!`*(tag: TypeBase): Type {.inline.} =
-  Type(kind: tyCompound, base: tag, baseArguments: @[])
-
-proc `[]`*(tag: TypeBase, args: varargs[Type]): Type {.inline.} =
+proc compound*(tag: TypeBase, args: varargs[Type]): Type {.inline.} =
   Type(kind: tyCompound, base: tag, baseArguments: @args)
+
+template `!`*(tag: TypeBase): Type = compound(tag)
+template `[]`*(tag: TypeBase, args: varargs[Type]): Type = compound(tag, args)

--- a/src/abyzou/vm/primitives.nim
+++ b/src/abyzou/vm/primitives.nim
@@ -148,7 +148,8 @@ type
     tyUnion, tyIntersection, tyNot,
     tyBaseType,
     tyWithProperty,
-    tyCustomMatcher,
+    tyBase,
+    tySomeValue,
     # generic parameter
     tyParameter,
     # value container
@@ -170,11 +171,31 @@ type
   
   ParameterInstantiation* = Table[TypeParameter, Type]
 
+  NativeType* = enum
+    ntyNone,
+    # concrete
+    ntyNoneValue,
+    ntyInt32, ntyUint32, ntyFloat32, ntyBool,
+    ntyInt64, ntyUint64, ntyFloat64,
+    ntyReference,
+    ntyTuple, # XXX (2) make into tyComposite, tuple, named tuple, array (i.e. int^20) all at once
+    ntyFunction,
+    ntyList,
+    ntyString,
+    ntySet,
+    ntyTable,
+    ntyExpression, ntyStatement, ntyScope,
+    ntyType,
+    # typeclass
+    ntyContravariant
+
   TypeBase* = ref object
     # XXX generics?
     id*: TypeBaseId
     name*: string
+    nativeType*: NativeType
     arguments*: Type # tuple type
+    genericParams*: seq[TypeParameter]
     typeMatcher*: proc (pattern, t: Type): TypeMatch
     valueMatcher*: proc (v: Value, thisType: Type): bool
     # XXX (6) maybe add compare
@@ -228,10 +249,10 @@ type
     of tyWithProperty:
       typeWithProperty*: Box[Type]
       withProperty*: TypeBase
-    of tyCustomMatcher:
-      typeMatcher*: proc (t: Type): TypeMatch
-      valueMatcher*: proc (v: Value): bool
-      # XXX (6) maybe add compare
+    of tyBase:
+      typeBase*: TypeBase
+    of tySomeValue:
+      someValueType*: Box[Type]
     of tyParameter:
       parameter*: TypeParameter
     of tyValue:
@@ -678,7 +699,8 @@ proc `$`*(t: Type): string =
   of tyNot: "Not " & $t.notType
   of tyBaseType: "BaseType " & $t.baseKind
   of tyWithProperty: "WithProperty(" & $t.typeWithProperty & ", " & $t.withProperty & ")"
-  of tyCustomMatcher: "Custom"
+  of tyBase: "Base(" & $t.typeBase & ")"
+  of tySomeValue: "SomeValue(" & $t.someValueType & ")"
   of tyParameter: "Parameter(" & $t.parameter.name & ")"
   of tyValue: "Value(" & $t.value & ": " & $t.valueType & ")"
   #of tyGeneric:

--- a/src/abyzou/vm/primitives.nim
+++ b/src/abyzou/vm/primitives.nim
@@ -135,7 +135,6 @@ type
     # typeclass
     tyAny,
     tyUnion, tyIntersection, tyNot,
-    tyBaseType,
     tyWithProperty,
     tyBase,
     tySomeValue,
@@ -216,8 +215,6 @@ type
       operands*: seq[Type]
     of tyNot:
       notType*: Box[Type]
-    of tyBaseType:
-      baseKind*: TypeKind
     of tyWithProperty:
       typeWithProperty*: Box[Type]
       withProperty*: TypeBase
@@ -650,7 +647,6 @@ proc `$`*(t: Type): string =
   of tyUnion: "Union(" & $t.operands & ")"
   of tyIntersection: "Intersection(" & $t.operands & ")"
   of tyNot: "Not " & $t.notType
-  of tyBaseType: "BaseType " & $t.baseKind
   of tyWithProperty: "WithProperty(" & $t.typeWithProperty & ", " & $t.withProperty & ")"
   of tyBase: "Base(" & $t.typeBase & ")"
   of tySomeValue: "SomeValue(" & $t.someValueType & ")"
@@ -753,7 +749,7 @@ template nativeType(n: untyped, nt: NativeType, args: varargs[TypeBound]) =
     arguments: toTypeParams(args))
 
 template nativeType(n: untyped, args: varargs[TypeBound]) =
-  nativeType(n, `nty n`, args)
+  nativeType(`n Ty`, `nty n`, args)
 
 template nativeAtomicType(n: untyped) =
   nativeType(`n TyBase`, `nty n`)
@@ -773,15 +769,15 @@ nativeAtomicType String
 nativeAtomicType Expression
 nativeAtomicType Statement
 nativeAtomicType Scope
-nativeType ReferenceTy, [+AnyTy]
-nativeType ListTy, ntyList, [+AnyTy]
-nativeType SetTy, ntySet, [+AnyTy]
-nativeType TableTy, ntyTable, [+AnyTy, +AnyTy]
-nativeType FunctionTy, ntyFunction, [+Type(kind: tyBase, typeBase: TupleTy), -Type(kind: tyUnion, operands: @[])]
+nativeType Reference, [+AnyTy]
+nativeType List, [+AnyTy]
+nativeType Set, [+AnyTy]
+nativeType Table, [+AnyTy, +AnyTy]
+nativeType Function, [+Type(kind: tyBase, typeBase: TupleTy), -Type(kind: tyUnion, operands: @[])]
   # XXX (2) account for Fields and Defaults property of the `arguments` tuple type
   # only considered at callsite like nim, no semantic value
   # meaning this is specific to function type relation
-nativeType TypeTy, ntyType
+nativeType Type
 TypeTy.arguments = toTypeParams [+Type(kind: tyBase, typeBase: TypeTy)]
 
 nativeType ContravariantTy, ntyContravariant, [+AnyTy]

--- a/src/abyzou/vm/types.nim
+++ b/src/abyzou/vm/types.nim
@@ -1,7 +1,7 @@
 import "."/[primitives, values, ids], std/[tables, sets]
 
 proc property*(tag: TypeBase, args: varargs[Type]): Type {.inline.} =
-  Type(kind: tyCompound, base: tag, baseArguments: @args)
+  compound(tag, args)
 
 proc property*(prop: Type): Type {.inline.} =
   assert prop.kind == tyCompound

--- a/src/abyzou/vm/types.nim
+++ b/src/abyzou/vm/types.nim
@@ -1,88 +1,5 @@
 import "."/[primitives, values, ids], std/[tables, sets]
 
-proc `+`*(t: Type): TypeBound {.inline.} = TypeBound(boundType: t, variance: Covariant)
-proc `-`*(t: Type): TypeBound {.inline.} = TypeBound(boundType: t, variance: Contravariant)
-proc `~`*(t: Type): TypeBound {.inline.} = TypeBound(boundType: t, variance: Invariant)
-proc `*`*(t: Type): TypeBound {.inline.} = TypeBound(boundType: t, variance: Ultravariant)
-proc `*`*(t: Type, variance: Variance): TypeBound {.inline.} = TypeBound(boundType: t, variance: variance)
-
-proc newTypeParameter*(name: string, bound: TypeBound = +Ty(Any)): TypeParameter =
-  TypeParameter(id: newTypeParameterId(), name: name, bound: bound)
-
-when defined(gcDestructors):
-  template defineTypeBase*(name, value): untyped {.dirty.} =
-    let `name`* = block: # !global
-      var `name` {.inject.}: TypeBase
-      `name` = value
-      `name`.id = newTypeBaseId()
-      `name`
-else:
-  template defineTypeBase*(name, value): untyped =
-    proc getTypeBase: TypeBase {.gensym.} =
-      var `name` {.global, inject.}: TypeBase
-      if `name`.isNil:
-        `name` = value
-        `name`.id = newTypeBaseId()
-      result = `name`
-    template `name`*: TypeBase {.inject.} = getTypeBase()
-
-when false: # can implement as compound types
-  {
-    # nullary
-    tyNoneValue, tyInt32, tyUint32, tyFloat32, tyBool,
-    tyInt64, tyUint64, tyFloat64, tyString, tyExpression, tyStatement, tyScope,
-    # unary
-    tyReference, tyList, tySet, tyType,
-    # binary
-    tyFunction, tyTable,
-    # typeclass
-    # nullary
-    tyAny,
-    # unary
-    tyNot,
-    # variadic
-    tyUnion, tyIntersection,
-    # complex
-    tyBaseType,
-    tyWithProperty}
-
-proc toTypeParams(args: varargs[TypeBound]): seq[TypeParameter] =
-  result.newSeq(args.len)
-  for i in 0 ..< args.len:
-    result[i] = newTypeParameter("", args[i])
-
-template nativeType(n: untyped, nt: NativeType, args: varargs[TypeBound]) =
-  defineTypeBase n, TypeBase(name: astToStr(n),
-    nativeType: nt,
-    arguments: toTypeParams(args))
-
-template nativeType(n: untyped, args: varargs[TypeBound]) =
-  nativeType(n, `nty n`, args)
-
-nativeType Tuple, [] # not used for tuple type construction
-
-nativeType NoneValue, []
-nativeType Int32, []
-nativeType Uint32, []
-nativeType Float32, []
-nativeType Bool, []
-nativeType Int64, []
-nativeType Uint64, []
-nativeType Float64, []
-nativeType String, []
-nativeType ExpressionTy, ntyExpression, []
-nativeType StatementTy, ntyStatement
-nativeType ScopeTy, ntyScope, []
-nativeType Reference, [+Type(kind: tyAny)]
-nativeType List, [+Type(kind: tyAny)]
-nativeType Set, [+Type(kind: tyAny)]
-nativeType Table, [+Type(kind: tyAny), +Type(kind: tyAny)]
-nativeType Function, [+Type(kind: tyBase, typeBase: Tuple), -Type(kind: tyAny)]
-nativeType TypeTy, ntyType
-TypeTy.arguments = toTypeParams [+Type(kind: tyBase, typeBase: TypeTy)]
-
-nativeType ContravariantTy, ntyContravariant, [+Type(kind: tyAny)]
-
 proc property*(tag: TypeBase, args: varargs[Type]): Type {.inline.} =
   Type(kind: tyCompound, base: tag, baseArguments: @args)
 
@@ -109,12 +26,8 @@ type TypeError* = object of CatchableError
 
 const
   allTypeKinds* = {low(TypeKind)..high(TypeKind)}
-  concreteTypeKinds* = {tyNoneValue..tyType}
+  concreteTypeKinds* = {tyTuple}
   typeclassTypeKinds* = {tyAny..tySomeValue}
-  atomicTypes* = {tyNoneValue,
-    tyInt32, tyUint32, tyFloat32, tyBool,
-    tyInt64, tyUint64, tyFloat64,
-    tyString, tyExpression, tyStatement, tyScope}
   allNativeTypes* = {low(NativeType)..high(NativeType)}
   concreteNativeTypes* = {ntyNoneValue..ntyType}
   highestNonMatching* = tmFalse
@@ -124,13 +37,13 @@ proc tupleType*(s: varargs[Type]): Type =
   Type(kind: tyTuple, elements: @s)
 
 proc funcType*(returnType: Type, arguments: varargs[Type]): Type {.inline.} =
-  Type(kind: tyFunction, returnType: returnType.box, arguments: tupleType(arguments).box)
+  FunctionTy[tupleType(arguments), returnType]
 
 proc tupleTypeWithVarargs*(s: varargs[Type], varargs: Type): Type =
   Type(kind: tyTuple, elements: @s, varargs: varargs.box)
 
 proc funcTypeWithVarargs*(returnType: Type, arguments: varargs[Type], varargs: Type): Type {.inline.} =
-  Type(kind: tyFunction, returnType: returnType.box, arguments: tupleTypeWithVarargs(arguments, varargs).box)
+  FunctionTy[tupleTypeWithVarargs(arguments, varargs), returnType]
 
 proc union*(s: varargs[Type]): Type =
   Type(kind: tyUnion, operands: @s)
@@ -138,25 +51,7 @@ proc union*(s: varargs[Type]): Type =
 const definiteTypeLengths*: array[TypeKind, int] = [
   tyNone: 0,
   tyCompound: -1,
-  tyNoneValue: 0,
-  tyInt32: 0,
-  tyUint32: 0,
-  tyFloat32: 0,
-  tyBool: 0,
-  tyInt64: 0,
-  tyUint64: 0,
-  tyFloat64: 0,
-  tyReference: 1,
   tyTuple: -1,
-  tyFunction: 2,
-  tyList: 1,
-  tyString: 0,
-  tySet: 1,
-  tyTable: 2,
-  tyExpression: 0,
-  tyStatement: 0,
-  tyScope: 0,
-  tyType: 1,
   tyAny: 0,
   tyUnion: -1,
   tyIntersection: -1,
@@ -188,17 +83,8 @@ proc hasNth*(t: Type, i: int): bool {.inline.} =
 
 proc nth*(t: Type, i: int): Type =
   case t.kind
-  of tyNoneValue,
-    tyInt32, tyUint32, tyFloat32, tyBool,
-    tyInt64, tyUint64, tyFloat64,
-    tyString, tyExpression, tyStatement, tyScope,
-    tyAny, tyNone:
+  of tyAny, tyNone:
     discard # inapplicable
-  of tyFunction:
-    if i == 0:
-      result = t.arguments.unbox
-    else:
-      result = t.returnType.unbox
   of tyTuple:
     if i < t.elements.len or t.varargs.isNone:
       result = t.elements[i]
@@ -206,15 +92,6 @@ proc nth*(t: Type, i: int): Type =
       result = t.varargs.unbox
   of tyCompound:
     result = t.baseArguments[i]
-  of tyReference, tyList, tySet:
-    result = t.elementType.unbox
-  of tyTable:
-    if i == 0:
-      result = t.keyType.unbox
-    else:
-      result = t.tableValueType.unbox
-  of tyType:
-    result = t.typeValue.unbox
   of tyUnion, tyIntersection:
     # this is actually not supposed to happen
     result = t.operands[i]
@@ -232,8 +109,8 @@ proc nth*(t: Type, i: int): Type =
     discard # what
 
 proc param*(t: Type, i: int): Type {.inline.} =
-  assert t.kind == tyFunction
-  t.arguments.unbox.nth(i)
+  assert t.kind == tyCompound and t.base.nativeType == ntyFunction
+  t.baseArguments[0].nth(i)
 
 proc matches*(tm: TypeMatch): bool {.inline.} =
   tm >= lowestMatching
@@ -310,47 +187,26 @@ proc match*(matcher, t: Type): TypeMatch =
         if m < res: res = m
         if res <= tmNone: return res
       res
-  of concreteTypeKinds:
+  of tyTuple:
+    # XXX (2) unorderedFields
+    # (name: string, age: int) is named tuple vs (name: string anywhere, age: int anywhere) is typeclass but also type of function call arguments
+    # second is strict subtype, like (name: string: 1, age: int: 2) vs (name: string: {1, 2}, age: int: {1, 2})
     if matcher.kind != t.kind:
-      return case t.kind
-      of concreteTypeKinds:
-        tmNone
-      else:
-        tmUnknown
-    case matcher.kind
-    of atomicTypes * concreteTypeKinds:
-      tmAlmostEqual
-    of tyReference, tyList, tySet:
-      match(+matcher.elementType.unbox, t.elementType.unbox)
-    of tyTuple:
-      # XXX (2) unorderedFields
-      # (name: string, age: int) is named tuple vs (name: string anywhere, age: int anywhere) is typeclass but also type of function call arguments
-      # second is strict subtype, like (name: string: 1, age: int: 2) vs (name: string: {1, 2}, age: int: {1, 2})
-      if matcher.elements.len != t.elements.len and matcher.varargs.isNone and t.varargs.isNone:
-        return tmNone
-      var max = t.elements.len
-      if matcher.elements.len > t.elements.len and (max = matcher.elements.len; t.varargs.isNone):
-        return tmNone
-      var res = tmAlmostEqual
-      for i in 0 ..< max:
-        let m = match(+matcher.nth(i), t.nth(i))
-        if m < res: res = m
-        if res <= tmNone: return res
-      if not matcher.varargs.isNone and not t.varargs.isNone:
-        let vm = match(+matcher.varargs.unbox, t.varargs.unbox)
-        if vm < res: res = vm
-      res
-    of tyFunction:
-      min(
-        match(-matcher.returnType.unbox, t.returnType.unbox),
-        match(+matcher.arguments.unbox, t.arguments.unbox))
-    of tyTable:
-      min(
-        match(+matcher.keyType.unbox, t.keyType.unbox),
-        match(+matcher.tableValueType.unbox, t.tableValueType.unbox))
-    of tyType:
-      match(+matcher.typeValue.unbox, t.typeValue.unbox)
-    of allTypeKinds - concreteTypeKinds: tmUnknown # unreachable
+      return tmUnknown
+    if matcher.elements.len != t.elements.len and matcher.varargs.isNone and t.varargs.isNone:
+      return tmNone
+    var max = t.elements.len
+    if matcher.elements.len > t.elements.len and (max = matcher.elements.len; t.varargs.isNone):
+      return tmNone
+    var res = tmAlmostEqual
+    for i in 0 ..< max:
+      let m = match(+matcher.nth(i), t.nth(i))
+      if m < res: res = m
+      if res <= tmNone: return res
+    if not matcher.varargs.isNone and not t.varargs.isNone:
+      let vm = match(+matcher.varargs.unbox, t.varargs.unbox)
+      if vm < res: res = vm
+    res
   of tyAny: tmTrue
   of tyNone: tmUnknown
   of tyUnion:
@@ -460,7 +316,7 @@ proc commonSubType*(a, b: Type, doUnion = true, variance = Covariant): Type =
   elif doUnion: # union here meaning either
     union(a, b)
   else:
-    Ty(None)
+    Type(kind: tyNone)
 
 proc commonSuperType*(a, b: Type, doUnion = true, variance = Covariant): Type =
   var m1, m2: TypeMatch
@@ -480,7 +336,7 @@ proc commonSuperType*(a, b: Type, doUnion = true, variance = Covariant): Type =
   elif doUnion:
     union(a, b)
   else:
-    Ty(None)
+    Type(kind: tyNone)
 
 import arrays
 
@@ -539,32 +395,8 @@ proc checkType*(value: FullValueObj, t: Type): bool =
     else:
       not b.valueMatcher.isNil and
         b.valueMatcher(value.toSmallValue, t)
-  of tyNoneValue: value.kind == vkNone
-  of tyInt32: value.kind == vkInt32
-  of tyUint32: value.kind == vkUint32
-  of tyFloat32: value.kind == vkFloat32
-  of tyBool: value.kind == vkBool
-  of tyInt64: value.kind == vkInt64
-  of tyUint64: value.kind == vkUint64
-  of tyFloat64: value.kind == vkFloat64
-  of tyFunction:
-    # XXX (4) no information about signature
-    value.kind in {vkFunction, vkNativeFunction}
   of tyTuple:
     value.kind == vkArray and value.tupleValue.unref.eachAre(t.elements)
-  of tyReference:
-    value.kind == vkReference and value.referenceValue.unref.checkType(t.elementType.unbox)
-  of tyList:
-    value.kind == vkList and value.listValue.unref.eachAre(t.elementType.unbox)
-  of tyString: value.kind == vkString
-  of tySet:
-    value.kind == vkSet and value.setValue.eachAre(t.elementType.unbox)
-  of tyTable:
-    value.kind == vkTable and value.tableValue.eachAreTable(t.keyType.unbox, t.tableValueType.unbox)
-  of tyExpression: value.kind == vkExpression
-  of tyStatement: value.kind == vkStatement
-  of tyScope: value.kind == vkScope
-  of tyType: value.kind == vkType and t.typeValue.unbox.match(value.typeValue).matches
   of tyAny: true
   of tyNone: false
   of tyUnion:
@@ -589,25 +421,7 @@ proc checkType*(value: FullValueObj, t: Type): bool =
     var vkinds: set[ValueKind]
     template vkind(vk: ValueKind) = vkinds = {vk}
     case t.baseKind
-    of tyNoneValue: vkind vkNone
-    of tyInt32: vkind vkInt32
-    of tyUint32: vkind vkUint32
-    of tyFloat32: vkind vkFloat32
-    of tyBool: vkind vkBool
-    of tyInt64: vkind vkInt64
-    of tyUint64: vkind vkUint64
-    of tyFloat64: vkind vkFloat64
-    of tyReference: vkind vkReference
-    of tyString: vkind vkString
-    of tyExpression: vkind vkExpression
-    of tyStatement: vkind vkStatement
-    of tyScope: vkind vkScope
-    of tyFunction: vkinds = {vkNativeFunction, vkFunction}
     of tyTuple: vkind vkArray
-    of tyList: vkind vkList
-    of tySet: vkind vkSet
-    of tyTable: vkind vkTable
-    of tyType: vkind vkType
     of tyAny, tyValue, tyCompound, tyBase: res = knownTrue
     of tyNone, tyUnion, tyIntersection, tyNot, tyBaseType, tyWithProperty,
       tySomeValue, tyParameter: res = knownFalse
@@ -654,22 +468,15 @@ proc matchParameters*(pattern, t: Type, table: var ParameterInstantiation, varia
       table[param] = newType
     else:
       table[param] = t
-  of tyNoneValue,
-    tyInt32, tyUint32, tyFloat32, tyBool,
-    tyInt64, tyUint64, tyFloat64,
-    tyString, tyExpression, tyStatement, tyScope,
-    tyAny, tyNone:
+  of tyAny, tyNone:
     discard # atoms
   of tyCompound:
     if unlikely(not pattern.base.genericMatcher.isNil):
       pattern.base.genericMatcher(pattern, t, table, variance)
     else:
       if t.kind == pattern.kind:
-        match(tupleType(pattern.baseArguments), tupleType(t.baseArguments))
-  of tyFunction:
-    if t.kind == tyFunction:
-      match(pattern.arguments, t.arguments)
-      matchParameters(pattern.returnType.unbox, t.returnType.unbox, table, variance = Contravariant)
+        for i in 0 ..< min(pattern.baseArguments.len, t.baseArguments.len):
+          match(pattern.baseArguments[i], t.baseArguments[i])
   of tyTuple:
     if t.kind == tyTuple:
       let
@@ -694,19 +501,6 @@ proc matchParameters*(pattern, t: Type, table: var ParameterInstantiation, varia
           match(pattern.elements[pattern.elementNames[name]], f)
         elif name in pattern.unorderedFields:
           match(pattern.unorderedFields[name], f)
-  of tyReference, tyList, tySet:
-    if t.kind == pattern.kind:
-      match(pattern.elementType, t.elementType)
-  of tyTable:
-    if t.kind == pattern.kind:
-      match(pattern.keyType, t.keyType)
-      match(pattern.tableValueType, t.tableValueType)
-  of tyType:
-    if t.kind == pattern.kind:
-      match(pattern.typeValue, t.typeValue)
-    else:
-      # wonky
-      match(pattern.typeValue.unbox, t)
   of tyUnion, tyIntersection, tyNot:
     discard # should not be able to match anything
   of tyWithProperty:
@@ -736,11 +530,7 @@ proc fillParameters*(pattern: var Type, table: ParameterInstantiation) =
   case pattern.kind
   of tyParameter:
     pattern = table[pattern.parameter]
-  of tyNoneValue,
-    tyInt32, tyUint32, tyFloat32, tyBool,
-    tyInt64, tyUint64, tyFloat64,
-    tyString, tyExpression, tyStatement, tyScope,
-    tyAny, tyNone, tyBaseType, tyBase:
+  of tyAny, tyNone, tyBaseType, tyBase:
     discard
   of tyCompound:
     if unlikely(not pattern.base.genericFiller.isNil):
@@ -748,22 +538,12 @@ proc fillParameters*(pattern: var Type, table: ParameterInstantiation) =
     else:
       for t in pattern.baseArguments.mitems:
         fill(t)
-  of tyFunction:
-    fill(pattern.arguments)
-    fill(pattern.returnType)
   of tyTuple:
     for e in pattern.elements.mitems:
       fill(e)
     fill(pattern.varargs)
     for _, e in pattern.unorderedFields.mpairs:
       fill(e)
-  of tyReference, tyList, tySet:
-    fill(pattern.elementType)
-  of tyTable:
-    fill(pattern.keyType)
-    fill(pattern.tableValueType)
-  of tyType:
-    fill(pattern.typeValue)
   of tyUnion, tyIntersection:
     for o in pattern.operands.mitems:
       fill(o)

--- a/src/abyzou/vm/values.nim
+++ b/src/abyzou/vm/values.nim
@@ -129,7 +129,7 @@ proc getType*(x: FullValueObj): Type =
     result = Ty(Table)
     for k, v in x.tableValue:
       result.keyType = k.getType.box
-      result.valueType = v.getType.box
+      result.tableValueType = v.getType.box
       break
   of vkEffect:
     # probably should never be here

--- a/src/abyzou/vm/values.nim
+++ b/src/abyzou/vm/values.nim
@@ -94,42 +94,42 @@ proc getType*(x: Value): Type
 proc getType*(x: FullValueObj): Type =
   if not x.type.isNil: return x.type[]
   case x.kind
-  of vkNone: result = Ty(NoneValue)
-  of vkInt32: result = Ty(Int32)
-  of vkUint32: result = Ty(Uint32)
-  of vkFloat32: result = Ty(Float32)
-  of vkInt64: result = Ty(Int64)
-  of vkUint64: result = Ty(Uint64)
-  of vkFloat64: result = Ty(Float64)
-  of vkBool: result = Ty(Bool)
-  of vkReference: result = Type(kind: tyReference, elementType: box x.referenceValue[].getType)
+  of vkNone: result = NoneValueTy
+  of vkInt32: result = Int32Ty
+  of vkUint32: result = Uint32Ty
+  of vkFloat32: result = Float32Ty
+  of vkInt64: result = Int64Ty
+  of vkUint64: result = Uint64Ty
+  of vkFloat64: result = Float64Ty
+  of vkBool: result = BoolTy
+  of vkReference: result = ReferenceTy[x.referenceValue[].getType]
   of vkBoxed: result = getType(x.boxedValue[])
-  of vkList: result = Type(kind: tyList, elementType: x.listValue.unref[0].getType.box)
-  of vkString: result = Ty(String)
-  of vkExpression: result = Ty(Expression)
-  of vkStatement: result = Ty(Statement)
-  of vkScope: result = Ty(Scope)
+  of vkList: result = ListTy[x.listValue.unref[0].getType]
+  of vkString: result = StringTy
+  of vkExpression: result = ExpressionTy
+  of vkStatement: result = StatementTy
+  of vkScope: result = ScopeTy
   of vkArray:
     let val = x.tupleValue.unref
     result = Type(kind: tyTuple, elements: newSeq[Type](val.len))
     for i in 0 ..< x.tupleValue.unref.len:
       result.elements[i] = val[i].getType
   of vkType:
-    result = Type(kind: tyType, typeValue: box x.typeValue)
+    result = TypeTy[x.typeValue]
   of vkFunction, vkNativeFunction:
-    result = Ty(Function)
+    result = Type(kind: tyBase, typeBase: FunctionTy)
     # could save signature into Function object
     # but we can still use the type field
   of vkSet:
-    result = Ty(Set)
+    result = SetTy[AnyTy]
     for v in x.setValue:
-      result.elementType = v.getType.box
+      result.baseArguments[0] = v.getType
       break
   of vkTable:
-    result = Ty(Table)
+    result = TableTy[AnyTy, AnyTy]
     for k, v in x.tableValue:
-      result.keyType = k.getType.box
-      result.tableValueType = v.getType.box
+      result.baseArguments[0] = k.getType
+      result.baseArguments[1] = v.getType
       break
   of vkEffect:
     # probably should never be here
@@ -137,15 +137,15 @@ proc getType*(x: FullValueObj): Type =
 
 proc getType*(x: Value): Type =
   case x.kind
-  of vkNone: result = Ty(NoneValue)
-  of vkInt32: result = Ty(Int32)
-  of vkUint32: result = Ty(Uint32)
-  of vkFloat32: result = Ty(Float32)
-  of vkInt64: result = Ty(Int64)
-  of vkUint64: result = Ty(Uint64)
-  of vkFloat64: result = Ty(Float64)
-  of vkBool: result = Ty(Bool)
-  of vkReference: result = Type(kind: tyReference, elementType: box x.referenceValue[].getType)
+  of vkNone: result = NoneValueTy
+  of vkInt32: result = Int32Ty
+  of vkUint32: result = Uint32Ty
+  of vkFloat32: result = Float32Ty
+  of vkInt64: result = Int64Ty
+  of vkUint64: result = Uint64Ty
+  of vkFloat64: result = Float64Ty
+  of vkBool: result = BoolTy
+  of vkReference: result = ReferenceTy[x.referenceValue[].getType]
   of boxedValueKinds - {vkInt64, vkUint64, vkFloat64}:
     result = x.boxedValue[].getType
   of vkEffect:

--- a/tests/test_vm.nim
+++ b/tests/test_vm.nim
@@ -295,12 +295,12 @@ test "generic":
 module withGenericMeta:
   let T = Type(kind: tyParameter, parameter: newTypeParameter("T"))
   let f = define(result, "foo", funcType(Ty(Statement), [Ty(Scope), Ty(Expression)]).withProperties(
-    property(Meta, toValue funcType(Type(kind: tyList, elementType: box T), [T]))
+    property(Meta, funcType(Type(kind: tyList, elementType: box T), [T]))
   ))
   f.genericParams = @[T.parameter]
   result.top.define(f)
   let f2 = define(result, "foo", funcType(Ty(Statement), [Ty(Scope), Ty(Statement)]).withProperties(
-    property(Meta, toValue funcType(Type(kind: tyList, elementType: box Ty(Int32)), [Ty(Int32)]))
+    property(Meta, funcType(Type(kind: tyList, elementType: box Ty(Int32)), [Ty(Int32)]))
   ))
   result.top.define(f2)
   result.refreshStack()

--- a/tests/test_vm.nim
+++ b/tests/test_vm.nim
@@ -6,12 +6,12 @@ else:
 import abyzou, abyzou/vm/[primitives, values, types, compilation, arrays]
 
 test "type relation":
-  check {Ty(Int32).match(Ty(Float32)), Ty(Float32).match(Ty(Int32))} == {tmNone}
-  let a1 = Type(kind: tyTuple, elements: @[Ty(Scope)], varargs: box Ty(Expression))
-  let a2 = Type(kind: tyTuple, elements: @[Ty(Scope), Ty(Expression), Ty(Expression)])
+  check {(Int32Ty).match(Float32Ty), (Float32Ty).match(Int32Ty)} == {tmNone}
+  let a1 = Type(kind: tyTuple, elements: @[ScopeTy], varargs: box ExpressionTy)
+  let a2 = Type(kind: tyTuple, elements: @[ScopeTy, ExpressionTy, ExpressionTy])
   check {a1.match(a2), a2.match(a1)} == {tmAlmostEqual}
-  let a3 = Type(kind: tyTuple, elements: @[Ty(Scope)], varargs: box Ty(Any))
-  let a4 = Type(kind: tyTuple, elements: @[Ty(Scope)])
+  let a3 = Type(kind: tyTuple, elements: @[ScopeTy], varargs: box AnyTy)
+  let a4 = Type(kind: tyTuple, elements: @[ScopeTy])
   check a1.match(a3) == tmFalse
   check a3.match(a1) == tmTrue
   check {a1.match(a4), a4.match(a1), a3.match(a4), a4.match(a3)} == {tmAlmostEqual}
@@ -252,7 +252,7 @@ c = foo()
 import abyzou/vm/library/common
 
 module withVarargsFn:
-  define "max", funcTypeWithVarargs(Ty(Int32), [], Ty(Int32)), (doFn do:
+  define "max", funcTypeWithVarargs(Int32Ty, [], Int32Ty), (doFn do:
     var res = args[0].int32Value
     for i in 1 ..< args.len:
       let el = args[i].int32Value
@@ -274,10 +274,10 @@ max(3, 7, 4, 5)
 
 module withGeneric:
   let T = Type(kind: tyParameter, parameter: newTypeParameter("T"))
-  let f = define(result, "foo", funcType(Type(kind: tyList, elementType: box T), [T]))
+  let f = define(result, "foo", funcType(ListTy[T], [T]))
   f.genericParams = @[T.parameter]
   result.top.define(f)
-  let f2 = define(result, "foo", funcType(Type(kind: tyList, elementType: box Ty(Int32)), [Ty(Int32)]))
+  let f2 = define(result, "foo", funcType(ListTy[Int32Ty], [Int32Ty]))
   result.top.define(f2)
   result.refreshStack()
   result.stack.set f.stackIndex, toValue proc (args: openarray[Value]): Value =
@@ -294,25 +294,25 @@ test "generic":
 
 module withGenericMeta:
   let T = Type(kind: tyParameter, parameter: newTypeParameter("T"))
-  let f = define(result, "foo", funcType(Ty(Statement), [Ty(Scope), Ty(Expression)]).withProperties(
-    property(Meta, funcType(Type(kind: tyList, elementType: box T), [T]))
+  let f = define(result, "foo", funcType(StatementTy, [ScopeTy, ExpressionTy]).withProperties(
+    property(Meta, funcType(ListTy[T], [T]))
   ))
   f.genericParams = @[T.parameter]
   result.top.define(f)
-  let f2 = define(result, "foo", funcType(Ty(Statement), [Ty(Scope), Ty(Statement)]).withProperties(
-    property(Meta, funcType(Type(kind: tyList, elementType: box Ty(Int32)), [Ty(Int32)]))
+  let f2 = define(result, "foo", funcType(StatementTy, [ScopeTy, StatementTy]).withProperties(
+    property(Meta, funcType(ListTy[Int32Ty], [Int32Ty]))
   ))
   result.top.define(f2)
   result.refreshStack()
   result.stack.set f.stackIndex, toValue proc (args: openarray[Value]): Value =
     let scope = args[0].boxedValue.scopeValue
     result = toValue compile(scope, Expression(kind: Array,
-      elements: @[args[1].boxedValue.expressionValue]), +Ty(Any))
+      elements: @[args[1].boxedValue.expressionValue]), +AnyTy)
   result.stack.set f2.stackIndex, toValue proc (args: openarray[Value]): Value =
     result = toValue Statement(kind: skList,
-      knownType: Type(kind: tyList, elementType: box Ty(Int32)),
+      knownType: ListTy[Int32Ty],
       elements: @[Statement(kind: skUnaryInstruction,
-        knownType: Ty(Int32),
+        knownType: Int32Ty,
         unaryInstructionKind: NegInt,
         unary: args[1].boxedValue.statementValue)])
 


### PR DESCRIPTION
- [ ] use tyCompound for every concrete type except tuples, and maybe every typeclass
  - but still have a base type that represents tuples only artificially
- [ ] tyBaseType checks for compound bases
- [ ] expose to language

performance hit between 5-25%